### PR TITLE
Clean up ts configs and tsup configs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsup && tsc -p tsconfig.build.json",
+    "build": "tsup",
     "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@aecfolio/db": "workspace:*",

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -2,12 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": false,
-    "incremental": false,
-    "noEmit": false,
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "emitDeclarationOnly": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+    "noEmit": false
+  }
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,15 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "target": "es2024",
-    "lib": ["es2024"],
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "types": ["node"],
-    "jsx": "react-jsx",
-    "jsxImportSource": "hono/jsx"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -1,10 +1,15 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
+  tsconfig: "tsconfig.build.json",
   entry: ["src/index.ts"],
   format: ["esm"],
-  splitting: false,
+  dts: true,
+  sourcemap: true,
   clean: true,
+  splitting: false,
+  minify: true,
+  treeshake: true,
   external: ["pg"],
   noExternal: ["@aecfolio/db", "@aecfolio/shared"],
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "react-router-serve ./dist/server/index.js",
-    "typecheck": "react-router typegen && tsc --noEmit"
+    "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
     "@aecfolio/api": "workspace:*",

--- a/apps/web/react-router.config.ts
+++ b/apps/web/react-router.config.ts
@@ -3,4 +3,11 @@ import type { Config } from "@react-router/dev/config";
 export default {
   ssr: true,
   buildDirectory: "dist",
+  future: {
+    v8_middleware: true,
+    v8_splitRouteModules: true,
+    v8_viteEnvironmentApi: true,
+    v8_passThroughRequests: true,
+    v8_trailingSlashAwareDataRequests: true,
+  },
 } satisfies Config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,11 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["es2024", "dom", "dom.iterable"],
     "types": ["node", "vite/client"],
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
     "paths": {
@@ -14,7 +11,6 @@
     },
     "esModuleInterop": true,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
     "resolveJsonModule": true
   },
   "include": [

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsup && tsc -p tsconfig.build.json",
+    "build": "tsup",
     "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@aecfolio/ui": "workspace:*",

--- a/apps/worker/tsconfig.build.json
+++ b/apps/worker/tsconfig.build.json
@@ -2,12 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": false,
-    "incremental": false,
-    "noEmit": false,
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "declaration": true,
-    "emitDeclarationOnly": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+    "noEmit": false
+  }
 }

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -2,12 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "target": "es2024",
     "lib": ["es2024", "dom"],
-    "rootDir": "./src",
-    "outDir": "./dist",
+    "rootDir": "src",
     "types": ["node"],
     "jsx": "react-jsx"
   },

--- a/apps/worker/tsup.config.ts
+++ b/apps/worker/tsup.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
+  tsconfig: "tsconfig.build.json",
   entry: ["src/index.ts"],
   format: ["esm"],
-  splitting: false,
+  dts: true,
+  sourcemap: true,
   clean: true,
+  splitting: false,
+  minify: true,
+  treeshake: true,
   noExternal: ["@aecfolio/ui", "@aecfolio/shared"],
 });

--- a/packages/db/env.d.ts
+++ b/packages/db/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="node" />

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsup && tsc -p tsconfig.build.json",
+    "build": "tsup",
     "generate": "drizzle-kit generate",
     "migrate": "drizzle-kit migrate",
     "push": "drizzle-kit push",
     "studio": "drizzle-kit studio",
     "seed": "tsx src/seed.ts",
     "seed:fake": "tsx src/seed-fake.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@paralleldrive/cuid2": "catalog:",

--- a/packages/db/tsconfig.build.json
+++ b/packages/db/tsconfig.build.json
@@ -2,12 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": false,
-    "incremental": false,
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "noEmit": false,
-    "declaration": true,
-    "emitDeclarationOnly": true
-  },
-  "include": ["src/**/*.ts"]
+    "noEmit": false
+  }
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -2,12 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "target": "es2024",
-    "lib": ["es2024"],
-    "rootDir": ".",
+    "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "drizzle.config.ts"]
+  "include": ["src"]
 }

--- a/packages/db/tsup.config.ts
+++ b/packages/db/tsup.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
+  tsconfig: "tsconfig.build.json",
   entry: ["src/index.ts"],
   format: ["esm"],
-  splitting: false,
+  dts: true,
+  sourcemap: true,
   clean: true,
+  splitting: false,
+  minify: true,
+  treeshake: true,
   external: ["pg"],
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,11 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "target": "es2024",
-    "lib": ["es2024"],
-    "rootDir": "."
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@aecfolio/shared": "workspace:*",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,12 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "target": "es2024",
     "lib": ["es2024", "dom"],
     "jsx": "react-jsx",
-    "rootDir": ".",
+    "rootDir": "src",
     "types": ["node"]
   },
   "include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "target": "es2024",
+    "lib": ["es2024"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true


### PR DESCRIPTION
- Move common fields to root tsconfig (target, lib, module, moduleResolution)
- Remove duplicate code from tsconfig.build.json files
- Move build config to tsup instead
- Move dts generation to tsup as well and simplify build commands to just `tsup`

Additionally enable RR7 future flags to silent noisy build outputs